### PR TITLE
Bump Avalonia 0.8.0 to 0.10.x

### DIFF
--- a/src/AvaloniaBootrapper.cs
+++ b/src/AvaloniaBootrapper.cs
@@ -16,7 +16,7 @@ namespace PSAvalonia
             new CustomAssemblyLoadContext().LoadNativeLibraries();
             new CustomAssemblyLoadContext().LoadLibs();
             App = new App();
-            AppBuilder.Configure(App).UsePlatformDetect().SetupWithoutStarting();
+            AppBuilder.Configure( () => App ).UsePlatformDetect().SetupWithoutStarting();
         }
 
         public static void ForceInit()
@@ -24,9 +24,8 @@ namespace PSAvalonia
 
         }
 
-        public static Window Load(string xaml) {
-            var loader = new AvaloniaXamlLoader();
-            return (Window)loader.Load(xaml);
+        public static Window Load( string absolutepath ) {
+            return (Window)AvaloniaXamlLoader.Load( new System.Uri( absolutepath ) );
         }
 
         public static void Start(Window window)

--- a/src/AvaloniaBootrapper.cs
+++ b/src/AvaloniaBootrapper.cs
@@ -24,8 +24,9 @@ namespace PSAvalonia
 
         }
 
-        public static Window Load( string absolutepath ) {
-            return (Window)AvaloniaXamlLoader.Load( new System.Uri( absolutepath ) );
+        public static Window Load( string xaml ) {
+            return AvaloniaRuntimeXamlLoader.Parse<Window>( xaml );
+            // return (Window)AvaloniaXamlLoader.Load( new System.Uri( absolutepath ) );
         }
 
         public static void Start(Window window)

--- a/src/Cmdlets.cs
+++ b/src/Cmdlets.cs
@@ -12,7 +12,7 @@ namespace PSAvalonia
         public string Xaml { get; set; }
 
         protected override void ProcessRecord() {
-            var window = AvaloniaBootstrapper.Load(Xaml);
+            var window = AvaloniaBootstrapper.Load( Xaml );
             WriteObject(window);
         }
     }

--- a/src/PSAvalonia.csproj
+++ b/src/PSAvalonia.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="**\*.xaml.cs">
@@ -11,9 +12,9 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.8.0" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.8.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.8.0" />
+    <PackageReference Include="Avalonia" Version="0.10.*" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.*" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.*" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
   </ItemGroup>

--- a/src/PSAvalonia.csproj
+++ b/src/PSAvalonia.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Avalonia" Version="0.10.*" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.*" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.*" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.*" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR bumps Avalonia to 0.10.x

The main reason that this has taken so long was, because of https://github.com/AvaloniaUI/Avalonia/issues/6777

The resolution was to use the runtime XAML Loader instead of the main XAML Loader.

The main XAML Loader requires a pre-existing code-behind assembly to have been compiled and loaded.